### PR TITLE
Reexport `num-traits`

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -4,7 +4,7 @@
 mod test;
 
 use crate::{axis::Axis, coord::Vec2};
-use num::traits::{
+pub use num::traits::{
     CheckedAdd,
     CheckedSub,
     One,


### PR DESCRIPTION
to facilitate Newtype pattern for generics.

Hi! Is there any reasons not to reexport some useful crates?